### PR TITLE
Updated source freshness to 1 week warn, 2 weeks error

### DIFF
--- a/models/sources/owid/src_owid_schema.yml
+++ b/models/sources/owid/src_owid_schema.yml
@@ -3,10 +3,10 @@ version: 2
 # Define an anchor for your common freshness settings
 freshness_defaults: &default_freshness
   warn_after:
-    count: 1
+    count: 7
     period: day
   error_after:
-    count: 2
+    count: 14
     period: day
 
 sources:


### PR DESCRIPTION
What:
Updated source freshness to 1 week warn, 2 weeks error
Why:
Weekly updates have been scheduled. Therefore, the timeframe expanded.