### PR TITLE
Fixed code error and removed logging in grants.

### DIFF
--- a/macros/utility/grant_select_to_role.sql
+++ b/macros/utility/grant_select_to_role.sql
@@ -35,5 +35,4 @@
       "GRANT SELECT ON ALL VIEWS IN SCHEMA " ~ db ~ "." ~ schema ~ " TO ROLE " ~ target_role
   ) %}
 
-  {{ return("Permissions granted to role `" ~ target_role ~ "` on " ~ db ~ "." ~ schema) }}
 {% endmacro %}


### PR DESCRIPTION
What:
Build out database grants on run end.
Why:
Automate reporting grants.