### PR TITLE
Changed the filename of the S3 file to skip overwrite until the file …

### DIFF
--- a/.github/workflows/refresh-covid-csv-to-s3.yml
+++ b/.github/workflows/refresh-covid-csv-to-s3.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download latest OWID COVID dataset
         run: |
           mkdir -p data
-          curl -sS -o data/owid-covid-data.csv https://covid.ourworldindata.org/data/owid-covid-data.csv
+          curl -sS -o data/owid-covid-data_tmp.csv https://covid.ourworldindata.org/data/owid-covid-data.csv
 
       - name: Sync to S3
         uses: jakejarvis/s3-sync-action@master


### PR DESCRIPTION
What:
Changed the filename for the S3 csv created.
Why:
In order to isolate/iterate file creation and not impact the production csv.