### PR TITLE
Fix/removing packages lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dbt_packages/
 logs/
 
 .DS_Store
+
+package-lock.yml
+packages-lock.json

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,8 +1,0 @@
-packages:
-  - name: dbt_utils
-    package: dbt-labs/dbt_utils
-    version: 1.3.0
-  - name: audit_helper
-    package: dbt-labs/audit_helper
-    version: 0.12.1
-sha1_hash: 3cb7f17573f37ab74d212002e5f1d512f16c2db2


### PR DESCRIPTION
What?
Testing docs generation w/out packages lock file
Why?
It's throwing an error on dpt deps on github