### PR TITLE
Re-run docs generation workflow after removing packages-lock.json

### DIFF
--- a/.github/workflows/generate-dbt-docs.yml
+++ b/.github/workflows/generate-dbt-docs.yml
@@ -25,8 +25,12 @@ jobs:
         with:
           python-version: '3.9'
 
+      - name: Install dbt & adapter
+        run: |
+          pip install dbt-core dbt-snowflake
+
       - name: Run dbt deps, generate, and compile docs
-        uses: dbt-labs/action@v2
+        uses: dbt-labs/action@v1
         with:
           project-dir: .
           install-deps: true


### PR DESCRIPTION
Another iteration to confirm that deleting packages-lock.json allows the GitHub Actions docs workflow to complete successfully.