### PR TITLE
fix: remove package-lock.json from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,3 @@ dbt_packages/
 logs/
 
 .DS_Store
-
-package-lock.yml
-packages-lock.json


### PR DESCRIPTION
Removed the package-lock.yml from .gitignore. That was originally added to support docs generation, but believe it's likely unnecessary. 