### PR TITLE
chore: upgrade dbt_utils to >=1.3.0

### DIFF
--- a/package-lock.yml
+++ b/package-lock.yml
@@ -5,4 +5,4 @@ packages:
   - name: audit_helper
     package: dbt-labs/audit_helper
     version: 0.12.1
-sha1_hash: 3cb7f17573f37ab74d212002e5f1d512f16c2db2
+sha1_hash: 70d443610edc449fe346f1824aaeef01a4b73205

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,6 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: [">=1.0.0", "<2.0.0"]
+    version: [">=1.3.0", "<2.0.0"]
 
   - package: dbt-labs/audit_helper
     version: [">=0.12.1", "<0.13.0"]


### PR DESCRIPTION
Updates `packages.yml` to require dbt_utils v1.3.0+ (the latest available 1.x release) and commits the regenerated lock file. This ensures CI installs a version of dbt_utils without the deprecated macro patch files.