### PR TITLE
feat: add not_null tests to OWID source iso_code & date columns

### DIFF
--- a/models/sources/owid/src_owid_schema.yml
+++ b/models/sources/owid/src_owid_schema.yml
@@ -39,12 +39,18 @@ sources:
         columns:
           - name: iso_code
             description: '{{ doc("owid_iso_code") }}'
+            tests:
+              - not_null:
+                  severity: warn            
           - name: continent
             description: '{{ doc("owid_continent") }}'
           - name: location
             description: '{{ doc("owid_location") }}'
           - name: date
             description: '{{ doc("owid_observation_dt") }}'
+            tests:
+              - not_null:       
+                  severity: warn                   
           - name: total_cases
             description: '{{ doc("owid_total_cases") }}'
           - name: new_cases

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,0 +1,8 @@
+packages:
+  - name: dbt_utils
+    package: dbt-labs/dbt_utils
+    version: 1.3.0
+  - name: audit_helper
+    package: dbt-labs/audit_helper
+    version: 0.12.1
+sha1_hash: 3cb7f17573f37ab74d212002e5f1d512f16c2db2


### PR DESCRIPTION
This adds `not_null` tests on the `iso_code` and `date` columns in `src_owid_schema.yml` to catch missing key values at the source layer.  
Both tests are set to warn severity to match our project defaults.  
