### PR TITLE
chore: remove packages-lock.yml and ignore it going forward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ dbt_packages/
 logs/
 
 .DS_Store
+
+packages-lock.yml
+packages-lock.json

--- a/package-lock.yml
+++ b/package-lock.yml
@@ -1,8 +1,0 @@
-packages:
-  - name: dbt_utils
-    package: dbt-labs/dbt_utils
-    version: 1.3.0
-  - name: audit_helper
-    package: dbt-labs/audit_helper
-    version: 0.12.1
-sha1_hash: 3cb7f17573f37ab74d212002e5f1d512f16c2db2


### PR DESCRIPTION
This PR deletes the `packages-lock.yml` file and adds it to `.gitignore`, restoring the previous behavior where docs generation worked without a lock file. Moving forward, dependency resolution will be dynamic, matching the configuration that succeeded in earlier CI runs.
