### PR TITLE
chore: increase freshness threshold to 8 day cadence

### DIFF
--- a/models/marts/owid/fct_owid_covid_schema.yml
+++ b/models/marts/owid/fct_owid_covid_schema.yml
@@ -224,7 +224,7 @@ models:
       data_type: TIMESTAMP_TZ
       tests:
         - test_freshness_threshold:
-            threshold_hours: 24
+            threshold_hours: 192
             severity: warn
     - name: dbt_model_name
       description: '{{ doc(''dbt_model_name'') }}'


### PR DESCRIPTION
Updates the freshness threshold for the fct_owid_covid_loaded_ts test to 8 days, matching our weekly OWID data refresh schedule and silencing the WARN-level duplicate‐row freshness alerts.
