### PR TITLE
chore: Refactor grant_reporting_access macro to run only on prod

### DIFF
--- a/macros/utility/grant_reporting_access.sql
+++ b/macros/utility/grant_reporting_access.sql
@@ -11,13 +11,16 @@
 
 
 {% macro grant_reporting_access() %}
-  {% set sql %}
-    GRANT USAGE ON SCHEMA REPORTING.MARTS TO ROLE analyst_role;
-    GRANT SELECT ON ALL TABLES IN SCHEMA REPORTING.MARTS TO ROLE analyst_role;
-    GRANT SELECT ON FUTURE TABLES IN SCHEMA REPORTING.MARTS TO ROLE analyst_role;
-    GRANT USAGE ON SCHEMA REPORTING.MARTS TO ROLE developer_role;
-    GRANT SELECT ON ALL TABLES IN SCHEMA REPORTING.MARTS TO ROLE developer_role;
-    GRANT SELECT ON FUTURE TABLES IN SCHEMA REPORTING.MARTS TO ROLE developer_role;
-  {% endset %}
-  {% do run_query(sql) %}
+  {% if target.name == 'prod' %}
+    {% set sql %}
+      GRANT USAGE ON SCHEMA REPORTING.MARTS TO ROLE {{ var('analyst_role') }};
+      GRANT SELECT ON ALL TABLES IN SCHEMA REPORTING.MARTS TO ROLE {{ var('analyst_role') }};
+      GRANT SELECT ON FUTURE TABLES IN SCHEMA REPORTING.MARTS TO ROLE {{ var('analyst_role') }};
+      GRANT USAGE ON SCHEMA REPORTING.MARTS TO ROLE {{ var('developer_role') }};
+      GRANT SELECT ON ALL TABLES IN SCHEMA REPORTING.MARTS TO ROLE {{ var('developer_role') }};
+      GRANT SELECT ON FUTURE TABLES IN SCHEMA REPORTING.MARTS TO ROLE {{ var('developer_role') }};
+    {% endset %}
+    {% do run_query(sql) %}
+  {% endif %}
 {% endmacro %}
+


### PR DESCRIPTION
This change moves the target-name check into the grant_reporting_access() macro itself, so that all downstream grants execute only when target.name is prod. Non-prod runs will no longer error out on the missing REPORTING.MARTS schema.