### PR TITLE
chore: centralize model configs in schema files and clean up SQL models

### DIFF
--- a/models/intermediate/owid/int_owid_covid.sql
+++ b/models/intermediate/owid/int_owid_covid.sql
@@ -1,5 +1,5 @@
 -- Created:       2024-05-01
--- Last Modified: 2025-05-10
+-- Last Modified: 2025-05-23
 -- Creator:       Eric Ramsaier
 -- Model:         int_owid_covid
 -- Purpose:       Resolve duplicate records in the OWID COVID dataset by keeping the most complete row per (owid_iso_code, observation_dt)
@@ -9,12 +9,6 @@
 --   - Source data may contain multiple rows per day due to OWID updates
 --   - See background in: analyses/data_issues/owid_covid_data_duplicates.md
 
-
-{{
-  config(
-    tags=['int', 'owid']
-  )
-}}
 
 WITH stg_data AS (
     SELECT * FROM {{ ref('stg_owid_covid_data') }}

--- a/models/intermediate/owid/int_owid_covid_schema.yml
+++ b/models/intermediate/owid/int_owid_covid_schema.yml
@@ -1,0 +1,9 @@
+version: 2
+
+models:
+  - name: int_owid_covid
+    description: "Intermediate transformations on OWID COVID staging"
+    tags:
+      - int
+      - covid
+      - owid

--- a/models/marts/owid/aggs/agg_owid_covid_month.sql
+++ b/models/marts/owid/aggs/agg_owid_covid_month.sql
@@ -1,5 +1,5 @@
 -- Created:       2025-05-10
--- Last Modified: 2025-05-10
+-- Last Modified: 2025-05-23
 -- Creator:       Eric Ramsaier
 -- Model:         agg_owid_covid_month
 -- Purpose:       Aggregates COVID metrics by continent and observation date
@@ -8,11 +8,6 @@
 --   - Aggregates key metrics like cases, deaths, and tests at the continent/month grain
 --   - Excludes rows where continent is NULL
 
-{{
-  config(
-    tags=['agg','owid','covid']
-  )
-}}
 
 WITH base AS (
     SELECT *

--- a/models/marts/owid/aggs/agg_owid_covid_year.sql
+++ b/models/marts/owid/aggs/agg_owid_covid_year.sql
@@ -1,5 +1,5 @@
 -- Created:       2025-05-10
--- Last Modified: 2025-05-10
+-- Last Modified: 2025-05-23
 -- Creator:       Eric Ramsaier
 -- Model:         agg_owid_covid_year
 -- Purpose:       Aggregates COVID metrics by continent and observation date
@@ -8,11 +8,6 @@
 --   - Aggregates key metrics like cases, deaths, and tests at the continent/year grain
 --   - Excludes rows where continent is NULL
 
-{{
-  config(
-    tags=['agg','owid','covid']
-  )
-}}
 
 WITH base AS (
     SELECT *

--- a/models/marts/owid/dim_owid_covid_location.sql
+++ b/models/marts/owid/dim_owid_covid_location.sql
@@ -1,5 +1,5 @@
 -- Created:       2024-05-10
--- Last Modified: 2025-05-10
+-- Last Modified: 2025-05-23
 -- Creator:       Eric Ramsaier
 -- Model:         dim_owid_iso_code
 -- Purpose:       Provides a unique list of OWID ISO codes with associated location and continent
@@ -9,8 +9,7 @@
 
 {{
   config(
-    unique_key='sk_owid_iso_code',
-    tags=['dim', 'owid']
+    unique_key='sk_owid_iso_code'
   )
 }}
 

--- a/models/marts/owid/fct_owid_covid.sql
+++ b/models/marts/owid/fct_owid_covid.sql
@@ -1,5 +1,5 @@
 -- Created:       2024-05-05
--- Last Modified: 2025-05-10
+-- Last Modified: 2025-05-23
 -- Creator:       Eric Ramsaier
 -- Model:         fct_owid_covid
 -- Purpose:       Fact model for OWID COVID metrics, aggregated by country and observation date
@@ -15,10 +15,7 @@
     materialized='incremental',
     unique_key='sk_owid_iso_code',
     incremental_strategy='merge',
-    cluster_by = ['observation_dt', 'owid_iso_code'],
-    contract={'enforced': true},
-    on_schema_change='fail',
-    tags=['fct','owid']
+    cluster_by = ['observation_dt', 'owid_iso_code']
   )
 }}
 

--- a/models/marts/owid/fct_owid_covid_schema.yml
+++ b/models/marts/owid/fct_owid_covid_schema.yml
@@ -5,7 +5,10 @@ models:
     tags:
       - fct
       - owid
-      - daily
+      - covid
+    config:
+      contract: {enforced: true}
+      on_schema_change: fail
     meta:
       owner: "eramsaier@gmail.com"
       team: "analytics_engineering"

--- a/models/sources/owid/src_owid_schema.yml
+++ b/models/sources/owid/src_owid_schema.yml
@@ -30,7 +30,8 @@ sources:
           - owid
         description: "Our World in Data COVID-19 complete daily dataset per location"
         loaded_at_field: loaded_ts
-        freshness: *default_freshness
+        config:
+          freshness: *default_freshness
         meta:
           source_url: "https://covid.ourworldindata.org/data/owid-covid-data.csv"
           codebook:   "https://github.com/owid/covid-19-data/blob/master/public/data/owid-covid-codebook.csv"

--- a/models/staging/owid/stg_owid_covid_data.sql
+++ b/models/staging/owid/stg_owid_covid_data.sql
@@ -1,5 +1,5 @@
 -- Created:       2024-05-12
--- Last Modified: 2025-05-12
+-- Last Modified: 2025-05-23
 -- Creator:       Eric Ramsaier
 -- Model:         stg_owid_covid_data
 -- Purpose:       Staging model for OWID COVID-19 data. Cleans, renames, and casts fields from the raw OWID source table.
@@ -8,12 +8,6 @@
 --   - Filters source data in development using dev_data_filter macro
 --   - Data types are enforced at the sources layer; this model performs light reshaping only
 
-
-{{
-  config(
-    tags=['stg', 'owid']
-  )
-}}
 
 WITH source_data AS (
     SELECT *

--- a/models/staging/owid/stg_owid_covid_data_schema.yml
+++ b/models/staging/owid/stg_owid_covid_data_schema.yml
@@ -3,9 +3,9 @@ models:
   - name: stg_owid_covid_data
     description: Staging model for OWID COVID-19 data. Cleans, renames, and casts fields from the raw OWID source table.
     tags:
-      - fct
+      - stg
       - owid
-      - daily
+      - covid
     meta:
       owner: "eramsaier@gmail.com"
       team: "analytics_engineering"


### PR DESCRIPTION
This PR moves all model configurations and metadata (tags, contracts, schema change policies) from SQL files into their respective schema.yml files and removes redundant package-lock.yml from version control. All models now run cleanly with a single dbt build and pass their tests.