### PR TITLE
enhance: add surrogate key to int_owid_covid model

### DIFF
--- a/models/intermediate/owid/int_owid_covid.sql
+++ b/models/intermediate/owid/int_owid_covid.sql
@@ -42,6 +42,7 @@ final AS (
             ) DESC
         ) AS rn
       -- end dedup logic
+      , {{ dbt_utils.generate_surrogate_key(['owid_iso_code', 'observation_dt']) }} AS sk_owid_iso_code
 
     FROM
         stg_data

--- a/models/marts/owid/dim_owid_covid_location.sql
+++ b/models/marts/owid/dim_owid_covid_location.sql
@@ -18,20 +18,15 @@ int_data AS (
     SELECT * FROM {{ ref('int_owid_covid') }}
 ),
 
-fct_data AS (
-    SELECT * FROM {{ ref('fct_owid_covid') }}
-),
-
 final AS (
     SELECT DISTINCT
-        iso.sk_owid_iso_code
-      , int.owid_iso_code
-      , int.location
-      , int.continent
-    FROM int_data AS int
-    LEFT JOIN fct_data AS iso
-      ON int.owid_iso_code = iso.owid_iso_code
-    WHERE int.owid_iso_code IS NOT NULL
+        sk_owid_iso_code
+      , owid_iso_code
+      , location
+      , continent
+    FROM 
+        int_data
+
 )
 
 SELECT * FROM final

--- a/models/marts/owid/fct_owid_covid.sql
+++ b/models/marts/owid/fct_owid_covid.sql
@@ -33,7 +33,7 @@ owid_data AS (
 
 final as (
 SELECT
-      {{ dbt_utils.generate_surrogate_key( ['owid_iso_code', 'observation_dt'] ) }} AS sk_owid_iso_code
+      sk_owid_iso_code
     , owid_iso_code
     , observation_dt
     , total_cases


### PR DESCRIPTION
- Added deterministic surrogate key `sk_owid_iso_code` to the `int_owid_covid` model using `dbt_utils.generate_surrogate_key`.
- Updated `fct_owid_covid` and `dim_owid_covid_location` models to reference the new SK via join on `owid_iso_code` and `observation_dt`.
- Centralizes SK logic in the intermediate layer to follow DRY principles and enable consistent downstream joins.
- All tests and dbt build run successfully.