### PR TITLE
fix: Remove stale patch for deleted macro grant_select_to_role

### DIFF
--- a/macros/macros_schema.yml
+++ b/macros/macros_schema.yml
@@ -30,15 +30,6 @@ macros:
         description: "The varchar column containing currency values."
     returns: "A `DECIMAL(10,2)` expression."
 
-  - name: grant_select_to_role
-    description: >
-      Generates SQL to grant `SELECT` privileges on all models in the current
-      target schema to a specified role.
-    arguments:
-      - name: target_role
-        description: "The name of the role to which `SELECT` will be granted."
-    returns: "A series of `GRANT SELECT ON TABLE ... TO ROLE <target_role>;` statements."
-
   - name: generate_database_name
     description: >
       Overrides the default database for models:


### PR DESCRIPTION
- Deleted obsolete `grant_select_to_role` patch entry from macro properties file
- This macro was removed from the project, but the patch block was still triggering warnings in dbt Cloud job logs
- `test_freshness_threshold` patch retained (macro still present)
- Change is low-risk and should clean up the job output on next run