### PR TITLE
Remove stale patch for deleted macro test_freshness_threshold

### DIFF
--- a/macros/macros_schema.yml
+++ b/macros/macros_schema.yml
@@ -71,18 +71,3 @@ macros:
       - name: None
         description: "No arguments; automatically uses `this.identifier` and run context."
     returns: "A set of literal columns for auditing and lineage tracking."
-
-  - name: test_freshness_threshold
-    description: >
-      A reusable freshness test that fails if any record’s timestamp is older
-      than the specified number of hours.
-    arguments:
-      - name: model
-        description: The model being tested (e.g. `ref('my_model')`).
-      - name: column_name
-        description: The timestamp column to compare (unquoted).
-      - name: threshold_hours
-        description: Maximum allowed age in hours, relative to CURRENT_TIMESTAMP().
-      - name: warn_if
-        description: If `true`, issues a warning instead of an error when the test fails.
-    returns: A set of rows older than the given threshold.


### PR DESCRIPTION
- Removed leftover patch entry for `test_freshness_threshold` macro from macro properties file
- This macro was previously deleted, but the patch remained and caused a warning in dbt Cloud job runs
- This change should eliminate the final macro patch warning on future runs