### PR TITLE
Move fct_owid_covid model config and comments into properties file

### DIFF
--- a/models/marts/owid/fct_owid_covid.sql
+++ b/models/marts/owid/fct_owid_covid.sql
@@ -1,24 +1,3 @@
--- Created:       2024-05-05
--- Last Modified: 2025-05-23
--- Creator:       Eric Ramsaier
--- Model:         fct_owid_covid
--- Purpose:       Fact model for OWID COVID metrics, aggregated by country and observation date
--- Notes:
---   - Uses surrogate key sk_owid_covid from owid_iso_code + observation_dt
---   - Includes case, death, testing, and vaccination metrics plus demographic context
---   - Incremental model using 7-day cutoff for recent updates
---   - Enforced contract with on_schema_change='fail' for pipeline stability
-
-
-{{
-  config(
-    materialized='incremental',
-    unique_key='sk_owid_iso_code',
-    incremental_strategy='merge',
-    cluster_by = ['observation_dt', 'owid_iso_code']
-  )
-}}
-
 WITH
 owid_data AS (
   SELECT 

--- a/models/marts/owid/fct_owid_covid_properties.yml
+++ b/models/marts/owid/fct_owid_covid_properties.yml
@@ -1,7 +1,19 @@
 version: 2
 models:
   - name: fct_owid_covid
-    description: Fact table for OWID COVID-19 data with historical metrics per country and date.
+    description: |
+      **Fact model** for OWID COVID metrics, aggregated by country and observation date.
+
+      **Created**:        2024-05-05  
+      **Last modified**:  2025-05-28  
+      **Creator**:        Eric Ramsaier
+
+      **Notes**:  
+      - Uses surrogate key `sk_owid_covid` from `owid_iso_code` + `observation_dt`  
+      - Includes case, death, testing, and vaccination metrics plus demographic context  
+      - Incremental model using 7-day cutoff for recent updates  
+      - Enforced contract with `on_schema_change='fail'` for pipeline stability
+
     tags:
       - fct
       - owid
@@ -9,6 +21,14 @@ models:
     config:
       contract: {enforced: true}
       on_schema_change: fail
+
+      materialized: incremental
+      unique_key: sk_owid_iso_code
+      incremental_strategy: merge
+      cluster_by:
+        - observation_dt
+        - owid_iso_code
+
     meta:
       owner: "eramsaier@gmail.com"
       team: "analytics_engineering"


### PR DESCRIPTION
**What:** Move fct_owid_covid materialization and docs from inline SQL into its properties YAML.  
**Why:** Centralize static configs and metadata in YAML so dbt can surface them in `dbt docs` and keep SQL clean.

**Validation:**  
- `dbt parse` passes  
- `dbt build --select fct_owid_covid` still runs as incremental  