### PR TITLE
chore: remove or clean legacy header comments from macros and tests

### DIFF
--- a/macros/audit/log_model_run.sql
+++ b/macros/audit/log_model_run.sql
@@ -1,20 +1,3 @@
--- Created:       2024-04-30
--- Last Modified: 2025-05-10
--- Creator:       Eric Ramsaier
--- Macro:         log_model_run
--- Purpose:
---   - Logs metadata about each dbt model execution to the audit table.
---   - Captures model name, run timestamp, invocation ID, row count, and table location.
---
--- Usage:
---   - Intended to be used as a post-hook for fact or dimension models.
---   - Configure in dbt_project.yml using a +post-hook reference.
---
--- Requirements:
---   - The target audit table must exist: dwh.audit.model_run_log
---   - Ensure proper permissions are in place for INSERT statements on that table.
-
-
 {% macro log_model_run() %}
     INSERT INTO dwh.audit.model_run_log (
         model_name,

--- a/macros/audit/standard_audit_columns.sql
+++ b/macros/audit/standard_audit_columns.sql
@@ -1,7 +1,3 @@
--- Created:       2024-04-30
--- Last Modified: 2025-05-10
--- Creator:       Eric Ramsaier
--- Macro:         standard_audit_columns
 -- Purpose:
 --   - Appends standard audit metadata fields to a model's SELECT list.
 --   - Includes model name, invocation ID, run start timestamp, and record load timestamp.

--- a/macros/macros_schema.yml
+++ b/macros/macros_schema.yml
@@ -52,9 +52,21 @@ macros:
     returns: "The resolved schema name for materializations."
 
   - name: log_model_run
-    description: >
-      Emits a post‐hook SQL snippet to log metadata about each model run
-      (model name, run timestamp, invocation ID, row count) to an audit table.
+    description: |
+      Logs metadata about each dbt model execution to the audit table, capturing:
+       - model name  
+       - run timestamp  
+       - invocation ID  
+       - row count  
+       - table location  
+
+      **Usage:**  
+      Intended as a `post-hook` for fact or dimension models; configure in `dbt_project.yml` under `+post-hook`.  
+
+      **Requirements:**  
+      - The audit table `dwh.audit.model_run_log` must already exist.  
+      - The executing role needs INSERT permissions on that table.
+ 
     arguments:
       - name: None
         description: "No arguments; intended for use as a post‐hook in `dbt_project.yml`."

--- a/macros/naming/generate_database_name.sql
+++ b/macros/naming/generate_database_name.sql
@@ -1,7 +1,3 @@
--- Created:       2024-04-30
--- Last Modified: 2025-05-10
--- Creator:       Eric Ramsaier
--- Macro:         generate_database_name
 -- Purpose:
 --   - Overrides default dbt behavior for database selection.
 --   - In production targets ("prod" or "production"), uses the configured custom_database_name.

--- a/macros/naming/generate_schema_name.sql
+++ b/macros/naming/generate_schema_name.sql
@@ -1,4 +1,3 @@
--- Source: https://docs.getdbt.com/docs/build/custom-schemas#an-alternative-pattern-for-generating-schema-names
 -- Purpose:
 --   - Overrides default dbt behavior for schema naming.
 --   - Forces all non-prod environments to write to a shared schema (e.g., dbt_eramsaier).
@@ -6,7 +5,8 @@
 -- Notes:
 --   - This macro is actively used to control environment-specific schema resolution.
 --   - Do not delete or rename — removal may break deployments in dev or staging.
-
+--
+-- Source: https://docs.getdbt.com/docs/build/custom-schemas#an-alternative-pattern-for-generating-schema-names
 
 {% macro generate_schema_name(custom_schema_name, node) -%}
   {%- if target.name in ['prod','production'] and custom_schema_name is not none -%}

--- a/macros/utility/dev_data_filter.sql
+++ b/macros/utility/dev_data_filter.sql
@@ -1,7 +1,3 @@
--- Created:       2024-04-30
--- Last Modified: 2025-05-10
--- Creator:       Eric Ramsaier
--- Macro:         dev_data_filter
 -- Purpose:
 --   - Injects a WHERE clause to limit rows in the dev environment to the last N days.
 --   - Helps reduce query size and execution time in development.

--- a/macros/utility/to_currency.sql
+++ b/macros/utility/to_currency.sql
@@ -1,7 +1,3 @@
--- Created:       2024-04-30
--- Last Modified: 2025-05-10
--- Creator:       Eric Ramsaier
--- Macro:         to_currency
 -- Purpose:
 --   - Converts a VARCHAR currency string to DECIMAL(10, 2).
 --   - Standardizes numeric formatting for financial fields across models.

--- a/macros/utility/to_timestamp.sql
+++ b/macros/utility/to_timestamp.sql
@@ -1,7 +1,3 @@
--- Created:       2024-04-30
--- Last Modified: 2025-05-12
--- Creator:       Eric Ramsaier
--- Macro:         to_timestamp
 -- Purpose:       Casts a column to TIMESTAMP_TZ to enforce UTC standardization.
 -- Notes:
 --   - Use to normalize timestamp types across sources and models.

--- a/tests/generic/test_freshness_threshold.sql
+++ b/tests/generic/test_freshness_threshold.sql
@@ -1,4 +1,3 @@
--- Macro: test_freshness_threshold
 -- Description:
 --   A reusable dbt test macro to validate that records in a model are fresh.
 --   It checks if the difference between a specified timestamp column and the current timestamp exceeds a threshold.

--- a/tests/owid/test_fct_owid_covid_data_no_future_dates.sql
+++ b/tests/owid/test_fct_owid_covid_data_no_future_dates.sql
@@ -1,8 +1,3 @@
--- Created:       2025-05-13
--- Last Modified: 2025-05-13
--- Creator:       Eric Ramsaier
--- Test:          no_future_dates_dim_owid_iso_code
--- Model:         test_fct_owid_covid_data_no_future_dates
 -- Purpose:       Ensure that no records in the test_fct_owid_covid_data_no_future_dates model have dates in the future
 -- Notes:
 --   - Protects against bad loads or clock-skew that could insert future-dated records


### PR DESCRIPTION
What: Strip out outdated -- Created/-- Last Modified/-- Macro header comments from all macro .sql files, leaving only Purpose and Notes where needed.
Why: Consolidate high-level documentation in macros_schema.yml and improve readability of the macro code itself.

Validation:
dbt parse passes
dbt docs generate shows updated macro descriptions under “Macros” without header clutter