### PR TITLE
Move the materialization config from properties yml to SQL file for fct_owid_covid

### DIFF
--- a/models/marts/owid/fct_owid_covid.sql
+++ b/models/marts/owid/fct_owid_covid.sql
@@ -1,3 +1,12 @@
+{{
+  config(
+    materialized='incremental',
+    unique_key='sk_owid_iso_code',
+    incremental_strategy='merge',
+    cluster_by = ['observation_dt', 'owid_iso_code']
+  )
+}}
+
 WITH
 owid_data AS (
   SELECT 

--- a/models/marts/owid/fct_owid_covid_properties.yml
+++ b/models/marts/owid/fct_owid_covid_properties.yml
@@ -17,13 +17,6 @@ models:
       contract: {enforced: true}
       on_schema_change: fail
 
-      materialized: incremental
-      unique_key: sk_owid_iso_code
-      incremental_strategy: merge
-      cluster_by:
-        - observation_dt
-        - owid_iso_code
-
     meta:
       owner: "eramsaier@gmail.com"
       team: "analytics_engineering"


### PR DESCRIPTION
What:
Moved the materialization config from properties yml to SQL file for fct_owid_covid.

Why:
To keep materialization logic with the SQL model.