### PR TITLE
Added dbt_valid_to_current default for owid covid location snapshot

### DIFF
--- a/snapshots/owid/dim_owid_covid_location_snapshot_properties.yml
+++ b/snapshots/owid/dim_owid_covid_location_snapshot_properties.yml
@@ -21,6 +21,7 @@ snapshots:
         - location
         - continent
       hard_deletes: new_record
+      dbt_valid_to_current: "TO_DATE('9999-12-31')"
 
     columns:
       - name: sk_owid_iso_code


### PR DESCRIPTION
What:
Added the default of 9999-12-31 as the dbt_valid_to_current.

Why:
To eliminate NULL in the valid-to field, making querying easier.